### PR TITLE
🔧 eslint, prettier 설정 파일 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,31 @@
+{
+  // 환경
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  // 플러그인 사용
+  "extends": [
+    // 설치한 플러그인들의 recommended 규칙을 전부 사용하겠다는 의미
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:import/recommended",
+    "plugin:jsx-a11y/recommended",
+    "plugin:prettier/recommended"
+  ],
+  // lint가 이해할 수 있는 언어가 JS밖에 없기때문에 다른 확장 문법 사용 시, 파서를 사용하도록 설정해야한다.
+  "parserOptions": {
+    // ECMAScript의 언어 확장 기능 설정
+    "ecmaFeatures": {
+      "jsx": true // JSX 사용 여부
+    },
+    "ecmaVersion": "latest", // ECMAScript 버전
+    "sourceType": "module" // 파서의 export 형태
+  },
+
+  // 사용할 규칙 설정, 0-off, 1-warn, 2-error
+  "rules": {
+    "react/react-in-jsx-scope": 0,
+    "react/jsx-uses-react": 0
+  }
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "singleQuote": true,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi":true,
+  "bracketSpacing": true,
+  "jsxBracketSameLine":false,
+  "jsxSingleQuote": false
+}
+


### PR DESCRIPTION
## ESlint, pretteir 설정 파일 추가

### ESLint
```json
{
  // 환경
  "env": {
    "browser": true,
    "es2021": true
  },
  // 플러그인 사용
  "extends": [
    // 설치한 플러그인들의 recommended 규칙을 전부 사용하겠다는 의미
    "eslint:recommended",
    "plugin:react/recommended",
    "plugin:import/recommended",
    "plugin:jsx-a11y/recommended",
    "plugin:prettier/recommended"
  ],
  // lint가 이해할 수 있는 언어가 JS밖에 없기때문에 다른 확장 문법 사용 시, 파서를 사용하도록 설정해야한다.
  "parserOptions": {
    // ECMAScript의 언어 확장 기능 설정
    "ecmaFeatures": {
      "jsx": true // JSX 사용 여부
    },
    "ecmaVersion": "latest", // ECMAScript 버전
    "sourceType": "module" // 파서의 export 형태
  },

  // 사용할 규칙 설정, 0-off, 1-warn, 2-error
  "rules": {
    "react/react-in-jsx-scope": 0,
    "react/jsx-uses-react": 0
  }
}
```

### Pretteir
```json
{
  "singleQuote": true,
  "tabWidth": 2,
  "useTabs": false,
  "semi":true,
  "bracketSpacing": true,
  "jsxBracketSameLine":false,
  "jsxSingleQuote": false
}
```
- 싱글따옴표 사용
- 탭 인덱스 크기 2
- 탭사용 강제 X
- 코드 마지막에 항상 세미콜론 추가
- {} 내 공간 가능
- jsx 닫는 >를 항상 다음줄에 두기 X
- jsx 내에 싱글따옴표 X
